### PR TITLE
ci: make registry publish jobs non-blocking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,9 +100,19 @@ jobs:
           draft: false
           prerelease: false
 
+  # Registry publishing is best-effort and must not fail the release.
+  # The GitHub Release (above) is the authoritative artifact — Arduino
+  # Library Manager indexes from the tag, and both registries below can
+  # be published by hand if the automated step does not go through:
+  #   pio pkg publish . --no-interactive
+  #   compote component upload --name fr_math --namespace deftio
+  # continue-on-error keeps a registry outage, or an expired/mis-scoped
+  # token, from marking an otherwise good release as failed. The job
+  # itself still shows as failed inside the run, so the signal is kept.
   publish-pio:
     needs: release
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - name: Install PlatformIO
@@ -115,6 +125,7 @@ jobs:
   publish-espressif:
     needs: release
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - name: Install compote (ESP Component Manager)


### PR DESCRIPTION
## Problem

The Release workflow reports failure whenever a package-registry publish fails, even though the GitHub Release itself succeeded. Healthy releases look broken to anyone glancing at the repo:

- **v2.0.9** — red X; `publish-espressif` could not authenticate (`token does not have the required scope: write:components`). The release, PlatformIO publish, and ESP-IDF publish all actually happened.
- **v2.0.8** — red X; same Espressif failure, plus `publish-pio` hit a transient registry HTTP 500.

## Change

Mark `publish-pio` and `publish-espressif` as `continue-on-error: true`, with a comment explaining why and recording the manual publish commands.

`validate` and `release` still block, so a genuine build/test failure or a failed GitHub Release fails the workflow as before.

## Why this is the right default

The GitHub Release is the authoritative artifact — Arduino Library Manager indexes from the tag, and both registries can be published by hand:

```
pio pkg publish . --no-interactive
compote component upload --name fr_math --namespace deftio
```

Registry availability and token validity are outside the repo's control, so they shouldn't gate the release status. Each job still surfaces its own failure inside the run, so the signal isn't lost — only the misleading top-level red X goes away.

## Follow-up (not in this PR)

The `IDF_COMPONENT_API_TOKEN` secret has never worked; the Espressif job was added in 2.0.8 and has failed on every run, with all registry versions published manually. Worth switching that job to Espressif's OIDC action (`espressif/upload-components-ci-action@v2` with `permissions: id-token: write`), which removes the long-lived secret entirely.

## Test plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` parses clean
- Verified `continue-on-error` is set on exactly the two publish jobs and not on `validate`/`release`
- Workflow-only change; no library, test, or doc files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMkVnPusE8nC7mrBE1NMJW